### PR TITLE
Hubot prefix on environment variables, and specify units

### DIFF
--- a/src/forecastio.coffee
+++ b/src/forecastio.coffee
@@ -6,12 +6,14 @@
 #
 # Configuration:
 #   HUBOT_FORECAST_IO_API_KEY
+#   HUBOT_FORECAST_IO_UNITS
 #
 # Commands:
 #   weather in {location}
 
 forecastIoApiKey = process.env.HUBOT_FORECAST_IO_API_KEY
-throw "You must set HUBOT_FORECAST_IO_API_KEY in your envrionment variables" unless forecastIoApiKey 
+throw "You must set HUBOT_FORECAST_IO_API_KEY in your envrionment variables" unless forecastIoApiKey
+forecastIoUnits = process.env.HUBOT_FORECAST_IO_UNITS || 'us'
 
 module.exports = (robot) ->
   robot.hear /weather in (.*)/i, (msg) ->
@@ -22,7 +24,7 @@ module.exports = (robot) ->
       formattedLocation = geocodeResponse.results[0].formatted_address
       lat = geocodeResponse.results[0].geometry.location.lat
       lng = geocodeResponse.results[0].geometry.location.lng
-      msg.http("https://api.forecast.io/forecast/#{forecastIoApiKey}/#{lat},#{lng}")
+      msg.http("https://api.forecast.io/forecast/#{forecastIoApiKey}/#{lat},#{lng}?units=#{forecastIoUnits}")
         .get() (err, res, body) ->
           forecastResponse = JSON.parse(body)
           minutely = ""

--- a/src/forecastio.coffee
+++ b/src/forecastio.coffee
@@ -5,13 +5,13 @@
 #   None
 #
 # Configuration:
-#   FORECAST_IO_API_KEY
+#   HUBOT_FORECAST_IO_API_KEY
 #
 # Commands:
 #   weather in {location}
 
-forecastIoApiKey = process.env.FORECAST_IO_API_KEY
-throw "You must set FORECAST_IO_API_KEY in your envrionment variables" unless forecastIoApiKey 
+forecastIoApiKey = process.env.HUBOT_FORECAST_IO_API_KEY
+throw "You must set HUBOT_FORECAST_IO_API_KEY in your envrionment variables" unless forecastIoApiKey 
 
 module.exports = (robot) ->
   robot.hear /weather in (.*)/i, (msg) ->

--- a/src/forecastio.coffee
+++ b/src/forecastio.coffee
@@ -9,14 +9,14 @@
 #   HUBOT_FORECAST_IO_UNITS
 #
 # Commands:
-#   weather in {location}
+#   hubot weather in {location}
 
 forecastIoApiKey = process.env.HUBOT_FORECAST_IO_API_KEY
 throw "You must set HUBOT_FORECAST_IO_API_KEY in your envrionment variables" unless forecastIoApiKey
 forecastIoUnits = process.env.HUBOT_FORECAST_IO_UNITS || 'us'
 
 module.exports = (robot) ->
-  robot.hear /weather in (.*)/i, (msg) ->
+  robot.respond /weather in (.*)/i, (msg) ->
     location = encodeURI(msg.match[1])
     msg.http("http://maps.googleapis.com/maps/api/geocode/json?address=#{location}&sensor=false")
     .get() (err, res, body) ->

--- a/test/forecastio-test.coffee
+++ b/test/forecastio-test.coffee
@@ -5,7 +5,7 @@ chai.use require 'sinon-chai'
 expect = chai.expect
 
 describe 'forecastio', ->
-  process.env.FORECAST_IO_API_KEY = '12345'
+  process.env.HUBOT_FORECAST_IO_API_KEY = '12345'
   beforeEach ->
     @robot =
       #respond: sinon.spy()

--- a/test/forecastio-test.coffee
+++ b/test/forecastio-test.coffee
@@ -8,13 +8,12 @@ describe 'forecastio', ->
   process.env.HUBOT_FORECAST_IO_API_KEY = '12345'
   beforeEach ->
     @robot =
-      #respond: sinon.spy()
-      hear: sinon.spy()
+      respond: sinon.spy()
 
     require('../src/forecastio')(@robot)
 
   #it 'registers a respond listener', ->
   #  expect(@robot.respond).to.have.been.calledWith(/weather in Jackson Heights, NY/)
 
-  it 'registers a hear listener', ->
-    expect(@robot.hear).to.have.been.calledWith(/weather in (.*)/i)
+  it 'registers a respond listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/weather in (.*)/i)


### PR DESCRIPTION
Fixes #1.

I've also taken the liberty of changing the command to be prefixed with 'hubot', let me know if you don't want this change.
